### PR TITLE
Fix for truncated WebSocket frames

### DIFF
--- a/src/http/socks_http_states_ws.cpp
+++ b/src/http/socks_http_states_ws.cpp
@@ -44,13 +44,15 @@ SOCKS_INLINE void HttpWsState::onEnter()
 
 SOCKS_INLINE void HttpWsState::onReceive(Byte const* buf, std::size_t len)
 {
-  try
-  {
     Byte const* buffer = buf;
     std::size_t length = len;
 
     while (length > 0) // when multiple ws frames are received
     {
+      if (length > Socks::Network::Tcp::MAX_SIZE)
+      {
+        throw std::invalid_argument("WebSocket frame invalid. (length > MAX_SIZE)");
+      }
       std::uint8_t opcode_;
       bool start = inBuf.size() == 0;
       std::size_t sizeRead;
@@ -95,11 +97,6 @@ SOCKS_INLINE void HttpWsState::onReceive(Byte const* buf, std::size_t len)
       }
       inBuf.clear();
     }
-  }
-  catch (std::invalid_argument& exc)
-  {
-    (void)exc;
-  }
 }
 
 SOCKS_INLINE void HttpWsState::onDisconnect() { handler->onDisconnect(); }

--- a/src/tcp/socks_tcp_types.hpp
+++ b/src/tcp/socks_tcp_types.hpp
@@ -11,8 +11,9 @@ namespace Network
 {
 namespace Tcp
 {
-constexpr std::size_t const MAX_SIZE = 4096;
-
+/* Size of worker thread receive buffer. */
+constexpr std::size_t const MAX_SIZE = 40960;
+/* Worker thread receive buffer. WebSocket frames are read from the tcp socket to this buffer. */
 using MsgBuf = std::array<Byte, MAX_SIZE>;
 } // namespace Tcp
 } // namespace Network

--- a/src/tcp/socks_tcp_worker.cpp
+++ b/src/tcp/socks_tcp_worker.cpp
@@ -35,13 +35,13 @@ SOCKS_INLINE void ClientWorker::run()
 
 SOCKS_INLINE void ClientWorker::loop()
 {
-  MsgBuf buf;
+  std::unique_ptr<MsgBuf> pBuf(new MsgBuf);
 
   while (!System::quitCondition() && !handler->connection()->isClosed())
   {
     if (socket->isReadable())
     {
-      auto len = socket->read(buf);
+      auto len = socket->read(*pBuf);
       if (len == Socket::NUM_EOF)
       {
         break;
@@ -50,7 +50,7 @@ SOCKS_INLINE void ClientWorker::loop()
       {
         continue;
       }
-      handler->onReceive(buf.data(), len);
+      handler->onReceive(pBuf->data(), len);
     }
   }
 }


### PR DESCRIPTION
 - Increased the tcp worker thread buffer size
 - Logging should also be turned off
   when receiving large amounts of receive data