### PR TITLE
SAFE-26567: WebSocket reconnect fix

### DIFF
--- a/examples/system_context/system_impl.hpp
+++ b/examples/system_context/system_impl.hpp
@@ -29,7 +29,7 @@ class SocketImpl final : public Socks::Network::Tcp::Socket
 {
   public:
   explicit SocketImpl(int fd);
-  ~SocketImpl() override {}
+  ~SocketImpl() override { close(); }
   ssize_t read(std::array<Socks::Byte, Socks::Network::Tcp::MAX_SIZE>& buf) override;
   ssize_t write(Socks::Byte const* buf, std::size_t buflen) override;
   virtual bool isReadable() const override;

--- a/src/http/socks_http.cpp
+++ b/src/http/socks_http.cpp
@@ -82,15 +82,14 @@ class TcpServerHandlerFactory final : public ServerHandlerFactory
   WsHandlerFactory& wsHandlerFactory;
 };
 
-SOCKS_INLINE void Server::serve(std::vector<std::string>& clientTypes, Context& context,
-                                HttpHandlerFactory& httpHandlerFactory, WsHandlerFactory& wsHandlerFactory,
-                                ServerOptions const& options)
+SOCKS_INLINE void Server::serve(Context& context, HttpHandlerFactory& httpHandlerFactory,
+                                WsHandlerFactory& wsHandlerFactory, ServerOptions const& options)
 {
   TcpServerHandlerFactory tcpHandlerFactory(httpHandlerFactory, wsHandlerFactory);
   Socks::Network::Tcp::ServerOptions tcpOptions(options.port, options.maxClients);
   Socks::Network::Tcp::Server server;
 
-  server.serve(clientTypes, context, tcpHandlerFactory, tcpOptions);
+  server.serve(context, tcpHandlerFactory, tcpOptions);
 }
 } // namespace Http
 } // namespace Network

--- a/src/http/socks_http.hpp
+++ b/src/http/socks_http.hpp
@@ -27,29 +27,29 @@ struct ServerOptions
 class Server final
 {
   public:
-  static void serve(std::vector<std::string>& clientTypes, Socks::Network::Tcp::Context& context,
+  static void serve(Socks::Network::Tcp::Context& context,
                     HttpHandlerFactory& httpHandlerFactory, WsHandlerFactory& wsHandlerFactory,
                     ServerOptions const& options = ServerOptions());
 
-  static inline void serve(std::vector<std::string>& clientTypes, Socks::Network::Tcp::Context& context,
+  static inline void serve(Socks::Network::Tcp::Context& context,
                            WsHandlerFactory& wsHandler, std::string const& basePath,
                            ServerOptions const& options = ServerOptions())
   {
     HttpFileHandlerFactory fileHandlerFactory(basePath);
-    serve(clientTypes, context, fileHandlerFactory, wsHandler, options);
+    serve(context, fileHandlerFactory, wsHandler, options);
   }
-  static inline void serve(std::vector<std::string>& clientTypes, Socks::Network::Tcp::Context& context,
+  static inline void serve(Socks::Network::Tcp::Context& context,
                            HttpHandlerFactory& httpHandlerFactory, ServerOptions const& options = ServerOptions())
   {
     WsHandlerNullFactory wsHandlerFactory;
-    serve(clientTypes, context, httpHandlerFactory, wsHandlerFactory, options);
+    serve(context, httpHandlerFactory, wsHandlerFactory, options);
   }
-  static inline void serve(std::vector<std::string>& clientTypes, Socks::Network::Tcp::Context& context,
+  static inline void serve(Socks::Network::Tcp::Context& context,
                            std::string const& basePath, ServerOptions const& options = ServerOptions())
   {
     HttpFileHandlerFactory fileHandlerFactory(basePath);
     WsHandlerNullFactory wsHandlerFactory;
-    serve(clientTypes, context, fileHandlerFactory, wsHandlerFactory, options);
+    serve(context, fileHandlerFactory, wsHandlerFactory, options);
   }
 
   private:

--- a/src/http/socks_ws_handler.hpp
+++ b/src/http/socks_ws_handler.hpp
@@ -68,27 +68,24 @@ class WsHandlerFactoryDefault : public WsHandlerFactory
 };
 
 
-template <class T, class L, class C>
+template <class T, class C>
 class WsHandlerFactoryMultiClient : public WsHandlerFactory
 {
   public:
   WsHandlerFactoryMultiClient() = default;
 
-  WsHandlerFactoryMultiClient(L& lock, C& content) : lock(lock), content(content){};
+  WsHandlerFactoryMultiClient(C& content) : content(content){};
 
   WsHandlerInstance createWsHandler(Socks::Network::Tcp::Connection* tcpConnection)
   {
-    T* newConnection = new T(tcpConnection);
+    T* newConnection = new T(tcpConnection, content);
 
-    lock.lock();
     content.newClient(newConnection);
-    lock.unlock();
 
     return WsHandlerInstance(newConnection);
   }
 
   private:
-  L& lock;
   C& content;
 };
 

--- a/src/tcp/socks_tcp.hpp
+++ b/src/tcp/socks_tcp.hpp
@@ -21,8 +21,7 @@ class Server final
 {
   public:
   Server() = default;
-  void serve(std::vector<std::string>& clientTypes, Context& context, ServerHandlerFactory& handlerFactory,
-             ServerOptions const& options = ServerOptions());
+  void serve(Context& context, ServerHandlerFactory& handlerFactory, ServerOptions const& options = ServerOptions());
 
   private:
   Server(Server&) = delete;

--- a/src/tcp/socks_tcp_worker.cpp
+++ b/src/tcp/socks_tcp_worker.cpp
@@ -22,12 +22,10 @@ SOCKS_INLINE void ClientWorker::run()
     handler->onConnect();
     loop();
     handler->onDisconnect();
-    socket->close();
   }
   catch (std::exception& exc)
   {
     handler->onDisconnect();
-    socket->close();
     std::cerr << exc.what() << std::endl;
   }
   _isActive = false;


### PR DESCRIPTION
 - Move TCP socket close from ClientWorker class to SocketImpl destructor
 - Remove unused clientTypes vector
 - Use connections mutex in ClientInformation class
   (instead of WsHandlerFactoryMultiClient)
 - Do cleanup of ClientWorkers immediately